### PR TITLE
Changes email forwarding

### DIFF
--- a/contact/form.html
+++ b/contact/form.html
@@ -31,7 +31,7 @@ title: Contact
             <label for="emailMessage">Message</label>
             <textarea required name="message" class="form-control" rows="10" placeholder="Please follow the guidance to the left about getting help." required title="Please follow the guidance to the left about getting help."></textarea>
           </div>
-          <input type="hidden" name="_redirect" value="/contact/success" />
+          <input type="hidden" name="_redirect" value="/contact/success">
           <button type="submit">Send</button>	
         </form>        
     </div>

--- a/contact/form.html
+++ b/contact/form.html
@@ -14,8 +14,11 @@ title: Contact
         </p>
     </div>
     <div class="col-md-6">
-        <!-- send this to another host (formspark.io) as GitHub Pages doesn't support -->
-        <form action="https://submit-form.com/kj7fWXmt">	
+        <!-- send this to another host (formspark) as GitHub doesn't support mail. -->
+        <form role="form" 
+          action="https://submit-form.com/BjWG1lX2"
+          data-botpoison-public-key="pk_016a2dd5-01de-4764-8a29-c4c0107438f0">
+          <script src="https://unpkg.com/@botpoison/browser" async></script>
           <div class="form-group">
             <label for="emailAddress">Email address</label>
             <input required name="sender" type="email" class="form-control" placeholder="Enter your email address. (We do not share this.)" autofocus />

--- a/contact/form.html
+++ b/contact/form.html
@@ -14,24 +14,22 @@ title: Contact
         </p>
     </div>
     <div class="col-md-6">
-        <!-- send this to another host as GitHub Pages doesn't support mail() -->
-        <form role="form" action="http://ccgi.jakeman.plus.com/or/forward_message.php" method="get">
+        <!-- send this to another host (formspark.io) as GitHub Pages doesn't support -->
+        <form action="https://submit-form.com/kj7fWXmt">	
           <div class="form-group">
             <label for="emailAddress">Email address</label>
-            <input type="email" class="form-control" id="emailAddress" name="from" placeholder="Enter your email address. (We do not share this.)" autofocus required>
+            <input required name="sender" type="email" class="form-control" placeholder="Enter your email address. (We do not share this.)" autofocus />
           </div>
           <div class="form-group">
             <label for="emailSubject">Subject</label>
-            <input type="text" class="form-control" id="emailSubject" name="subject" placeholder="Enter your subject">
+            <input required name="subject" type="text" class="form-control" placeholder="Enter your subject">
           </div>
-                        <input type="hidden" name="send_to_name"   value="or_website">
-                        <input type="hidden" name="send_to_domain" value="jakeman.plus.com">
-                            <input type="hidden" name="success_url"    value="http://openrails.org/contact/success"> 
           <div class="form-group">
             <label for="emailMessage">Message</label>
-            <textarea class="form-control" rows="10" id="emailMessage" name="body" placeholder="Please follow the guidance to the left about getting help." required title="Please follow the guidance to the left about getting help."></textarea>
+            <textarea required name="message" class="form-control" rows="10" placeholder="Please follow the guidance to the left about getting help." required title="Please follow the guidance to the left about getting help."></textarea>
           </div>
-          <button type="submit" class="btn btn-default">Send</button>
-        </form>
+          <input type="hidden" name="_redirect" value="/contact/success" />
+          <button type="submit">Send</button>	
+        </form>        
     </div>
 </div>

--- a/contact/form.html
+++ b/contact/form.html
@@ -21,7 +21,7 @@ title: Contact
           <script src="https://unpkg.com/@botpoison/browser" async></script>
           <div class="form-group">
             <label for="emailAddress">Email address</label>
-            <input required name="sender" type="email" class="form-control" placeholder="Enter your email address. (We do not share this.)" autofocus />
+            <input required name="sender" type="email" class="form-control" placeholder="Enter your email address. (We do not share this.)" autofocus>
           </div>
           <div class="form-group">
             <label for="emailSubject">Subject</label>


### PR DESCRIPTION
Uses formspark.io as email forwarder

Replace the link to ccgi.jakeman.plus.com which I no longer have access to.
This service also keeps a record of emails and their content and can be shared with other members too.

Also form fields are now "required".