### PR TITLE
Fix links

### DIFF
--- a/_data/files.yaml
+++ b/_data/files.yaml
@@ -1,12 +1,13 @@
 stable_installer:
-  url: http://openrails.org/files/OpenRails-1.5.1-Setup.exe
+  url: https://static.openrails.org/files/OpenRails-1.5.1-Setup.exe
   date: 2022-11-27
   bytes: 85092792
 stable_source:
-  url: http://openrails.org/files/OpenRails-1.5.1-Source.zip
+  url: https://static.openrails.org/files/OpenRails-1.5.1-Source.zip
   date: 2022-11-27
   bytes: 112062082
 testing_build:
+<<<<<<< Updated upstream
   url: https://github.com/openrails/openrails-testing/releases/download/T1.5.1-535-g2f57132ee/Open.Rails.T1.5.1-535-g2f57132ee.zip
   date: 2023-07-28
   bytes: 95776361
@@ -14,8 +15,17 @@ testing_source:
   url: https://github.com/openrails/openrails-testing/releases/download/T1.5.1-535-g2f57132ee/Open.Rails.T1.5.1-535-g2f57132ee.Source.zip
   date: 2023-07-28
   bytes: 147277360
+=======
+  url: https://static.openrails.org/files/OpenRails-Testing.zip
+  date: 2023-02-03
+  bytes: 95706807
+testing_source:
+  url: https://static.openrails.org/files/OpenRails-Testing-Source.zip
+  date: 2023-02-03
+  bytes: 147063174
+>>>>>>> Stashed changes
 testing_manual:
-  url: http://openrails.org/files/OpenRails-Testing-Manual.pdf
+  url: https://static.openrails.org/files/OpenRails-Testing-Manual.pdf
   date: 2023-02-03
   bytes: 36504088
 unstable_build:
@@ -27,11 +37,11 @@ unstable_source:
   date: tbd
   bytes: tbd
 doc_install_en:
-  url: /assets/files/installation_guide_en.pdf
+  url: https://static.openrails.org/files/OpenRails-Testing-Installation%20Guide%20En.pdf
   date: 2020-09-01
   bytes: 993137
 doc_install_es:
-  url: /assets/files/installation_guide_es.pdf
+  url: https://static.openrails.org/files/OpenRails-Testing-Installation%20Guide%20Es.pdf
   date: 2020-09-01
   bytes: 501541
 doc_german_keyboards:

--- a/_data/files.yaml
+++ b/_data/files.yaml
@@ -7,7 +7,6 @@ stable_source:
   date: 2022-11-27
   bytes: 112062082
 testing_build:
-<<<<<<< Updated upstream
   url: https://github.com/openrails/openrails-testing/releases/download/T1.5.1-535-g2f57132ee/Open.Rails.T1.5.1-535-g2f57132ee.zip
   date: 2023-07-28
   bytes: 95776361
@@ -15,15 +14,6 @@ testing_source:
   url: https://github.com/openrails/openrails-testing/releases/download/T1.5.1-535-g2f57132ee/Open.Rails.T1.5.1-535-g2f57132ee.Source.zip
   date: 2023-07-28
   bytes: 147277360
-=======
-  url: https://static.openrails.org/files/OpenRails-Testing.zip
-  date: 2023-02-03
-  bytes: 95706807
-testing_source:
-  url: https://static.openrails.org/files/OpenRails-Testing-Source.zip
-  date: 2023-02-03
-  bytes: 147063174
->>>>>>> Stashed changes
 testing_manual:
   url: https://static.openrails.org/files/OpenRails-Testing-Manual.pdf
   date: 2023-02-03

--- a/_data/news.yaml
+++ b/_data/news.yaml
@@ -1,12 +1,12 @@
 - date: 2023-01-01
   title: Portugal '79
   text:
-    - <a href="https://github.com/cpvirtual/OR_CPV.git">Portugal '79</a> has been published. 
+    - <a href="https://github.com/cpvirtual/OR_CPV.git" target="_blank">Portugal '79</a> has been published. 
       This provides 1775km of broad gauge track, with full detail on 91km between Entroncamento and Alfarelos.
 - date: 2023-01-01
   title: HSB Simulator
   text:
-    - New commercial route <a href="http://www.hsb-simulator.com/">HSB Simulator</a> published. 
+    - New commercial route <a href="http://www.hsb-simulator.com/" target="_blank">HSB Simulator</a> published. 
       This contains 87 miles of the Harz narrow-gauge railway, the longest narrow-gauge route network in Europe.
 - date: 2022-11-01
   title: Version 1.5.1
@@ -18,25 +18,25 @@
     - <a href="/discover/version-1-5/">Open Rails 1.5</a> released.
 - date: 2022-07-01
   text:
-    - Three new UK routes are now available for immediate download <a href="http://openrails.org/download/content/">here</a>.
+    - Three new UK routes are now available for immediate download <a href="/download/content/">here</a>.
 - date: 2021-10-19
   text:
     - <a href="/discover/version-1-4/">Version 1.4</a> is now available for immediate download <a href="/download/program/">here</a>.
 - date: 2020-11-17
   text:
-    - Wagons can now be braked individually as on the oldest railways. This can be experienced in 2 scenarios - <a href="https://www.coalstonewcastle.com.au/physics/stock/#rainhill">Stephenson's Rocket at Rainhill Trials</a> and <a href="https://www.coalstonewcastle.com.au/physics/stock/#select">Langley Vale Timber Tramway</a>.
+    - Wagons can now be braked individually as on the oldest railways. This can be experienced in 2 scenarios - <a href="https://www.coalstonewcastle.com.au/physics/stock/#rainhill" target="_blank">Stephenson's Rocket at Rainhill Trials</a> and <a href="https://www.coalstonewcastle.com.au/physics/stock/#select" target="_blank">Langley Vale Timber Tramway</a>.
 - date: 2020-04-01
   text:
-    - After more than a year of work <a href="http://www.siskurail.org/" title="Oregon to California, created by Dale Rickert">the free, restored and improved Siskiyou Route</a> is once more available.
+    - After more than a year of work <a href="http://www.siskurail.org/" target="_blank" title="Oregon to California, created by Dale Rickert">the free, restored and improved Siskiyou Route</a> is once more available.
 - date: 2019-04-01
   text:
-    - <a href="https://www.trainsim.com/vbts/tslib.php?searchid=13577139">ENG files published</a> with accurate physics for 176 USA diesel locos.
+    - <a href="https://www.trainsim.com/forums/forum/open-rails/open-rails-discussion/150974-orts-standard-engine-files" target="_blank">ENG files published</a> with accurate physics for 176 USA diesel locos.
 - date: 2018-12-01
   text:
     - <a href="/discover/version-1-3-1/">Open Rails 1.3.1</a> released <a href="/download/program/">Download it here</a>.
 - date: 2018-03-01
   text:
-    - Geoff Rowlands found a way to model 3D controls so they can be grabbed by the handle <a href="https://www.youtube.com/watch?v=UO9XrBz3iD0&feature=youtu.be">as in this video</a>.
+    - Geoff Rowlands found a way to model 3D controls so they can be grabbed by the handle <a href="https://www.youtube.com/watch?v=UO9XrBz3iD0&feature=youtu.be" target="_blank">as in this video</a>.
 - date: 2017-01-01
   title: Version 1.2
   text:
@@ -48,11 +48,11 @@
 - date: 2015-12-01
   title: More Access to Elvas Tower
   text:
-    - The Elvas Tower forum plays a major role in developing Open Rails but has been closed to non-members following a dispute. We can now report that some of the <a href="http://www.elvastower.com/forums/">Open Rails sub-forums</a> are open again.
+    - The Elvas Tower forum plays a major role in developing Open Rails but has been closed to non-members following a dispute. We can now report that some of the <a href="http://www.elvastower.com/forums/" target="_blank">Open Rails sub-forums</a> are open again.
 - date: 2015-06-01
   title: Great Zig Zag Railway
   text:
-    - Peter Newell has just released (June 2105) the <a href="http://www.zigzag.coalstonewcastle.com.au/">Great Zig Zag Railway</a>, a steam route for Open Rails v1.0 (this 120MB download requires no other files).
+    - Peter Newell has just released (June 2105) the <a href="http://www.zigzag.coalstonewcastle.com.au/" target="_blank">Great Zig Zag Railway</a>, a steam route for Open Rails v1.0 (this 120MB download requires no other files).
 - date: 2015-05-01
   title: Version 1.0
   text:
@@ -64,12 +64,12 @@
 - date: 2014-12-01
   title: 3D Cabs
   text:
-    - <a href="http://www.dekosoft.com">Dekosoft Trains</a> has added locos exclusively for Open Rails to its range. These are GP30 diesels taking advantage of our 3D cab feature.
+    - <a href="https://dekogames.com/trains/" target="_blank">Dekosoft Trains</a> has added locos exclusively for Open Rails to its range. These are GP30 diesels taking advantage of our 3D cab feature.
 - date: 2014-07-01
   title: Web Site
   text:
     - The legacy graphics-heavy web site has been replaced by one based on Bootstrap which is both easier to maintain and suitable for phones and tablets as well as PCs.
-    - You can still <a href="https://web.archive.org/web/20200809170400/http://openrails.org/web1/index.html">see an archive of the old site</a>.
+    - You can still <a href="https://web.archive.org/web/20200809170400/http://openrails.org/web1/index.html" target="_blank">see an archive of the old site</a>.
 - date: 2014-04-01
   title: Installer
   text:

--- a/contact/form.html
+++ b/contact/form.html
@@ -21,7 +21,7 @@ title: Contact
           <script src="https://unpkg.com/@botpoison/browser" async></script>
           <div class="form-group">
             <label for="emailAddress">Email address</label>
-            <input required name="sender" type="email" class="form-control" placeholder="Enter your email address. (We do not share this.)" autofocus />
+            <input required name="sender" type="email" class="form-control" placeholder="Enter your email address. (We do not share this.)" autofocus>
           </div>
           <div class="form-group">
             <label for="emailSubject">Subject</label>
@@ -31,7 +31,7 @@ title: Contact
             <label for="emailMessage">Message</label>
             <textarea required name="message" class="form-control" rows="10" placeholder="Please follow the guidance to the left about getting help." required title="Please follow the guidance to the left about getting help."></textarea>
           </div>
-          <input type="hidden" name="_redirect" value="/contact/success" />
+          <input type="hidden" name="_redirect" value="/contact/success">
           <button type="submit">Send</button>	
         </form>        
     </div>

--- a/contribute/building-models/index.html
+++ b/contribute/building-models/index.html
@@ -27,7 +27,7 @@ There are several products which support modelling in 3D and produce the formats
 <p>&nbsp;</p>
 <h2>Tutorials</h2>
 <p>
-<i>scottb613</i> has posted a <a href="http://www.trainsim.com/vbts/showthread.php?298900-Big-Dog-Birth-of-a-Steam-Locomotive/page7">tutorial for building locos</a> using 3DCrafter as a series of forum posts.
+<i>scottb613</i> has posted a <a href="https://www.trainsim.com/forums/forum/microsoft-train-simulator/msts-modeling-and-physics/msts-locomotive-design/122122-big-dog-birth-of-a-steam-locomotive" target="_blank">tutorial for building locos</a> using 3DCrafter as a series of forum posts.
 </p><p>
 <img src="/assets/les-ross.jpg" title="Built by bruce16 using 3DCrafter" alt="Built by bruce16 using 3DCrafter">
 </p><p>&nbsp;

--- a/learn/activities/index.html
+++ b/learn/activities/index.html
@@ -21,16 +21,16 @@ title: Activities
         </p><p>
           The activities are based on the free BNSF Scenic Route currently being offered by TrainSimulations (<a href="/">see our homepage</a>).
           There's a version for the route prior to 20-Oct-2020 and another for the more recent route. You can find them by searching the
-          "Open Rails - Open Rails Activities" section of the <a href="https://www.trainsim.com/vbts/tslib.php?do=displaysearch">TrainSim.com Library</a>
-          or download from these links:
+          "Open Rails - Open Rails Activities" section of the <a href="https://www.trainsim.com/forums/filelib-search-section?fcat=11&fsec=107">TrainSim.com File Library</a>
+          or view the item from these links:
           <ul>
-            <li>Pre 20-Oct-2020 <a href="https://www.trainsim.com/vbts/tslib.php?do=copyright&fid=36048">open_rails_starter_tutorial_1_0x.zip</a></li>
-            <li>and <a href="https://www.trainsim.com/vbts/tslib.php?do=copyright&fid=36050">open_rails_starter_tutorial_1_1.zip</a></li>
+            <li>Pre 20-Oct-2020 <a href="https://www.trainsim.com/forums/filelib-viewzip?fid=36048">open_rails_starter_tutorial_1_0x.zip</a></li>
+            <li>and <a href="https://www.trainsim.com/forums/filelib-viewzip?fid=36050">open_rails_starter_tutorial_1_1.zip</a></li>
           </ul>
           <ul>
-            <li>Post 20-Oct-2020 <a href="https://www.trainsim.com/vbts/tslib.php?do=copyright&fid=36266">open_rails_starter_tutorial_2.zip</a></li>
-            <li>Also <a href="https://www.trainsim.com/vbts/tslib.php?do=copyright&fid=36326">bnsf_scenic_atk8_11.zip</a> - Amtrak train meets 6 freight trains</li>
-            <li>and <a href="https://www.trainsim.com/vbts/tslib.php?do=copyright&fid=36293">ortsscenicsubtimetable.zip</a> - 14 drivable trains, 24-hour timetable</li>
+            <li>Post 20-Oct-2020 <a href="https://www.trainsim.com/forums/filelib-viewzip?fid=36266">open_rails_starter_tutorial_2.zip</a></li>
+            <li>Also <a href="https://www.trainsim.com/forums/filelib-viewzip?fid=36326">bnsf_scenic_atk8_11.zip</a> - Amtrak train meets 6 freight trains</li>
+            <li>and <a href="https://www.trainsim.com/forums/filelib-viewzip?fid=36293">ortsscenicsubtimetable.zip</a> - 14 drivable trains, 24-hour timetable</li>
           </ul>
         </p>
         <h3>Developing Activities - 2</h3>

--- a/share/community/index.html
+++ b/share/community/index.html
@@ -33,7 +33,6 @@ These boards have forums and files dedicated to Open Rails:</p>
   <li><a href="http://www.elvastower.com" target="_blank" title="(Open Rails forums are public, others require membership.)">Elvas Tower</a> - International and American and <br>also the <a href="http://www.elvastower.com/forums/index.php?/forum/190-open-rails-simulator-project/">home of the Open Rails Project Team</a></li>
   <li><a href="http://www.trainsim.com" target="_blank">TrainSim</a> - International and American</li>
   <li><a href="https://www.railpage.com.au/f-f61.htm" target="_blank">Railpage forum</a> - Australian</li>
-  <li><a href="http://www.uktrainsim.com" target="_blank">UKTrainSim</a> - British</li>
   <li><a href="https://tsforum.forumotion.net/" target="_blank" title="Dedicated to MSTS and Open Rails">Train Sim Safe House</a> - British</li>
   <li><a href="http://open-rails.forumczech.com" target="_blank">Czech Open Rails Forum</a> - Czech</li>
 	<li><a href="http://forum.treinpunt.nl/index.php/topic,65746.0.html" target="_blank">Trein Punt Open Rails Forum</a> - Dutch</li>

--- a/trade/index.html
+++ b/trade/index.html
@@ -7,7 +7,7 @@ title: Trade
     <div class="col-md-6">
 <h2>Supporting The Market In Open Rails Products</h2>
 <p>
-Open Rails is free software and the result of hours of time and talent freely given. Many compatible models of routes (e.g. <a href="http://www.uktrainsim.com/index2.php?form_news=readreport&amp;form_report=1755" target="_blank">Mid East Plus</a>),
+Open Rails is free software and the result of hours of time and talent freely given. Many compatible models of routes (e.g. <a href="https://github.com/MECoast/MECoast" target="_blank">Mid East Coast</a>),
 rolling stock and static content such as buildings have been published free of charge.
 </p><p>
 However, the Open Rails platform can also support commercial offerings in many forms, most obviously models. The Open Rails team has
@@ -26,13 +26,13 @@ modeling people or road traffic or moving water. A specialist could deliver and 
 These vendors sell or create products suitable for Open Rails:
 </p>
 <ul>
-  <li><a href="https://www.trainsimulations.net/">TrainSimulations</a> - Canada</li>
-  <li><a href="https://pikku.msts.cz/">Pikku Locomotive Works</a> - Czechoslovakia</li>
-  <li><a href="http://www.hsb-simulator.com/" title="Harz narrow-gauge railways">HSB Simulator</a> - Germany</li>
-  <li><a href="http://broadgaugeproduction.irts.in/">Broad Gauge Productions</a> - India</li>  
-  <li><a href="http://www.gabriele90.com/">Gabriele 90</a> - Italy</li>
+  <li><a href="https://www.trainsimulations.net/" target="_blank">TrainSimulations</a> - Canada</li>
+  <li><a href="https://pikku.msts.cz/" target="_blank">Pikku Locomotive Works</a> - Czechoslovakia</li>
+  <li><a href="http://www.hsb-simulator.com/" target="_blank" title="Harz narrow-gauge railways">HSB Simulator</a> - Germany</li>
+  <li><a href="http://broadgaugeproduction.irts.in/" target="_blank">Broad Gauge Productions</a> - India</li>  
+  <li><a href="http://www.gabriele90.com/" target="_blank">Gabriele 90</a> - Italy</li>
   <li><a href="http://www.3dtrains.com/" target="_blank">3DTrains</a> - USA</li>
-  <li><a href="https://dekogames.com/trains/">Deko Games</a> - USA</li>
+  <li><a href="https://dekogames.com/trains/" target="_blank">Deko Games</a> - USA</li>
 </ul>
 <p>&nbsp;</p>
 <h2>Vendors Supporting MSTS</h2>
@@ -43,7 +43,6 @@ These vendors sell or distribute products suitable for MSTS:
   <li><a href="http://www.valleypass.com/" target="_blank">BLW Productions</a> - Canada</li>
   <li><a href="http://www.mapleleaftracks.com" target="_blank">Maple Leaf Tracks</a> - Canada</li>
   <li><a href="https://www.simtrain.ch/" target="_blank">SimTrain.ch</a> - Switzerland</li>
-  <li><a href="http://www.uktrainsim.com" target="_blank">UKTrainSim</a> - UK</li>
   <li><a href="http://www.3dtrainstuff.com" target="_blank">3DTrainStuff</a> - USA and UK</li>
   <li><a href="http://www.dieselswest.com" target="_blank">DieselsWest</a> - USA</li>
   <li><a href="http://www.vscalecreations.com" target="_blank">V Scale Creations</a> - USA</li>


### PR DESCRIPTION
Used static.openrails.org where needed.
Also updated traingsim.com links for their new website.
Removed UKTrainSim.