### PR TITLE
Update Jekyll to match Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.1.1"
+gem "jekyll", "~> 4.3.3"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and


### PR DESCRIPTION
Jekyll 4.1.1 was not compatible with latest Ruby (3.3.1)