### PR TITLE
feat: Update pages to version 1.6

### DIFF
--- a/_data/menu.yaml
+++ b/_data/menu.yaml
@@ -9,8 +9,8 @@ toc:
         url: /discover/our-mission/
       - page: Roadmap
         url: /discover/roadmap/
-      - page: Version 1.5
-        url: /discover/version-1-5/
+      - page: Version 1.6
+        url: /discover/version-1-6/
       - page: Project Team
         url: /discover/project-team/
       - page: News

--- a/_data/news.yaml
+++ b/_data/news.yaml
@@ -1,3 +1,11 @@
+- date: 2025-04-01
+  title: Demo Model 1 route updated
+  text:
+    - Demo Model 1 route now features a 3D cab created by Geoff Rowlands.
+- date: 2024-10-09
+  title: Elvas Tower ownership
+  text:
+    - Elvas Tower changed owner - a critical transition has been smoothly achieved.
 - date: 2023-07-01
   title: New route from Train Simulations
   text:

--- a/_includes/program/preamble.html
+++ b/_includes/program/preamble.html
@@ -1,4 +1,4 @@
-<!-- completely changed the role of the preamble. It guides the user to the correct page instead of inititating the program download. -->
+<!-- completely changed the role of the preamble. It guides the user to the correct page instead of initiating the program download. -->
 {%- for preamble in page.preambles -%}
 <!-- Modal -->
 <div id='{{ preamble.modal }}' class='modal fade' tabindex='-1' role='dialog' aria-labelledby='myModalLabel' aria-hidden='true'>

--- a/contribute/credits/index.html
+++ b/contribute/credits/index.html
@@ -17,6 +17,7 @@ title: Credits
     <ul>
         <li>Adam Kane</li>
         <li>Adam Miles</li>
+        <li>Alberto Cruzado</li>
         <li>Alex Bloom</li>
         <li>Andre Ming</li>
         <li>Anthony Brailsford</li>
@@ -46,6 +47,7 @@ title: Credits
         <li>Eric Swenson</li>
         <li>Eugen Rippstein</li>
         <li>Fabian Joris</li>
+        <li>Gergely Lukács</li>
         <li>Greg Davies</li>
         <li>György Sárosi</li>
         <li>Haifeng Li</li>
@@ -80,6 +82,7 @@ title: Credits
         <li>Peter Gulyas</li>
         <li>Peter Newell</li>
         <li>Phil Voxland</li>
+        <li>Phillip	Schlichting</li>
     </ul>
     </div>
     <div class="col-md-3">
@@ -94,12 +97,14 @@ title: Credits
         <li>Robert Murphy</li>
         <li>Robert Roeterdink</li>
         <li>Roberto Ceccarelli</li>
+        <li>Roger Fischer</li>
         <li>Samuel Kelly</li>
         <li>Scott Miller</li>
         <li>Sid Penstone</li>
         <li>Tim Muir</li>
         <li>Walter Niehoff</li>
         <li>Wes Card</li>
+        <li>Weter</li>
     </ul>
     </div>
 </div>
@@ -109,8 +114,7 @@ title: Credits
         And a special thanks to:
     </p>
     <ul>
-        <li>Dave Nelson for providing us a meeting place at Elvas Tower</li>
-        <li>Pete Peddlesden for hosting our website and repository</li>
+        <li>Rui Fonseca and Dave Nelson for providing us a meeting place at Elvas Tower</li>
         <li>And, of course, Wayne Campbell for inspiring this improbable journey</li>
     </ul>
     </div>

--- a/discover/latest_stable_version/index.markdown
+++ b/discover/latest_stable_version/index.markdown
@@ -1,0 +1,6 @@
+---
+layout: default
+section: Discover
+title: Version 1.6
+redirect_to: /discover/version-1-6/
+---

--- a/discover/roadmap/index.html
+++ b/discover/roadmap/index.html
@@ -61,51 +61,51 @@ title: Roadmap
 			</thead>
 			<tbody>
 				<tr>
-					<td class="version">v1.6</td>
-					<td>&nbsp;</td>
-					<td>&nbsp;</td>
-					<td>&nbsp;</td>
-				</tr>
-				<tr>
-					<td class="blue"><a href=""></a></td>
-					<td class="red"><a href="https://trello.com/c/ZpMsbNDp/144-sets-of-1-10-cameras-that-players-can-switch-between">user-definable camera sets</a></td>
-					<td class="green"><a href="https://trello.com/c/N05HMaKn/350-darkness-in-tunnels">darkness in tunnels</a></td>
-					<td class="orange"><a href="https://trello.com/c/G7aoSuwy/270-content-directory-file-format">virtual filesystem</a></td>
-				</tr>
-				<tr>
-					<td class="blue"><a href=""></a></td>
-					<td class="red"><a href="https://trello.com/c/awrukdfm/425-customise-freight-animations-for-2d-3d-cabs">custom animations</a></td>
-					<td class="green"><a href="https://trello.com/c/QRIfnqhm/137-new-3d-model-format">new 3D model format (glTF)</a></td>
-					<td class="orange"><a href="https://trello.com/c/zma8vdQA/228-support-button-remapping-for-raildriver">remapping for RailDriver controls</a></td>
-				</tr>
-				<tr>
-					<td class="blue"><a href=""></a></td>
-					<td class="red"><a href=""></a></td>
-					<td class="green"><a href=""></a></td>
-					<td class="orange"><a href="https://trello.com/c/wRX5Q6IQ/139-foundation-for-interactive-content-on-secondary-screens-devices">web APIs for interactive content</a></td>
-				</tr>
-				<tr>
-					<td class="version">v ?</td>
+					<td class="version">v N</td>
 					<td>&nbsp;</td>
 					<td>&nbsp;</td>
 					<td>&nbsp;</td>
 				</tr>
 				<tr>
 					<td class="blue"><a href="https://trello.com/c/JGosmRnZ/159-consist-editor">consist editor</a></td>
+					<td class="red"><a href="https://trello.com/c/ZpMsbNDp/144-sets-of-1-10-cameras-that-players-can-switch-between">user-definable camera sets</a></td>
+					<td class="green"><a href="https://trello.com/c/QRIfnqhm/137-new-3d-model-format">new 3D model format (glTF)</a></td>
+					<td class="orange"><a href="https://trello.com/c/G7aoSuwy/270-content-directory-file-format">virtual filesystem</a></td>
+				</tr>
+				<tr>
+					<td class="blue"><a href=""></a></td>
+					<td class="red"><a href="https://trello.com/c/awrukdfm/425-customise-freight-animations-for-2d-3d-cabs">custom animations</a></td>
+					<td class="green"><a href="https://trello.com/c/N05HMaKn/350-darkness-in-tunnels">darkness in tunnels</a></td>
+					<td class="orange"><a href="https://trello.com/c/wRX5Q6IQ/139-foundation-for-interactive-content-on-secondary-screens-devices">web APIs for interactive content</a></td>
+				</tr>
+				<tr>
+					<td class="blue"><a href=""></a></td>
+					<td class="red"><a href=""></a></td>
+					<td class="green"><a href=""></a></td>
+					<td class="orange"><a href="https://trello.com/c/Mjmi2WsI/238-standalone-dispatcher-that-handles-server-host-admin">multi-player server</a></td>
+				</tr>
+				<tr>
+					<td class="version">v N+1</td>
+					<td>&nbsp;</td>
+					<td>&nbsp;</td>
+					<td>&nbsp;</td>
+				</tr>
+				<tr>
+					<td class="blue"><a href="https://trello.com/c/upvTt0M7/284-locomotive-editor">loco and wagon editor</a></td>
 					<td class="red"><a href="https://trello.com/c/LDJDHAAA/415-brakeman-mode">brakeman role</a></td>
 					<td class="green">
 						<a href="https://trello.com/c/AHLLtyoL/473-support-a-texture-layer-channel-for-objects-to-show-weathering-grime-ambient-occlusion-etc">ambient occlusion</a>
 					</td>
-					<td class="orange"><a href="https://trello.com/c/4GemLyo4/262-autosave">auto-save</a></td>
+					<td class="orange"><a href="https://trello.com/c/1hWlhrYL/140-in-game-gui-refresh-to-focus-on-user">better user-centred GUI</a></td>
 				</tr>
 				<tr>
-					<td class="blue"><a href="https://trello.com/c/upvTt0M7/284-locomotive-editor">loco and wagon editor</a></td>
+					<td class="blue"><a href=""></a></td>
 					<td class="red"><a href="https://trello.com/c/idi8r9TZ/184-steam-automatic-engineer-allowing-fully-manual-fireman-operations">fireman role</a></td>
 					<td class="green"><a href="https://trello.com/c/4oQrHy8o/175-multiple-light-sources">multiple light sources</a></td>
-					<td class="orange"><a href="https://trello.com/c/1YXKK7N5/164-publishing-and-downloading-content">self-installing content</a></td>
+					<td class="orange"><a href=""></a></td>
 				</tr>
 				<tr>
-					<td class="version">v ?</td>
+					<td class="version">v N+2</td>
 					<td>&nbsp;</td>
 					<td>&nbsp;</td>
 					<td>&nbsp;</td>
@@ -114,7 +114,7 @@ title: Roadmap
 					<td class="blue"><a href="https://trello.com/c/CmiYsij1/132-activity-editor">activity editor</a></td>
 					<td class="red"><a href="https://trello.com/c/rduLQ6Tz/114-content-defined-user-triggered-animations">custom animation triggers</a></td>
 					<td class="green"><a href="https://trello.com/c/BIVtZTOf/227-improved-smoke-for-steam-locomotives">distinguish steam and smoke</a></td>
-					<td class="orange"><a href="https://trello.com/c/1hWlhrYL/140-in-game-gui-refresh-to-focus-on-user">better user-centred GUI</a></td>
+					<td class="orange"><a href="https://trello.com/c/083N0XhA/138-separate-3d-viewer-from-other-code">multiple cameras concurrently</a></td>
 				</tr>
 				<tr>
 					<td class="blue"><a href="https://trello.com/c/5O1usjDV/160-timetable-editor">timetable editor</a></td>
@@ -123,7 +123,7 @@ title: Roadmap
 					<td class="orange"><a href=""></a></td>
 				</tr>
 				<tr>
-					<td class="version">v ?</td>
+					<td class="version">v N+3</td>
 					<td>&nbsp;</td>
 					<td>&nbsp;</td>
 					<td>&nbsp;</td>
@@ -132,10 +132,10 @@ title: Roadmap
 					<td class="blue"><a href="https://trello.com/c/C2hnNnGz/274-terrain-generator">terrain generator</a></td>
 					<td class="red"><a href="https://trello.com/c/1CO5wAfU/155-derailment-collision-detection">derailment/collision detection</a></td>
 					<td class="green"><a href="https://trello.com/c/NF46cEh6/183-msts-kosmos-environments">better MSTS/Kosmos environments</a></td>
-					<td class="orange"><a href="https://trello.com/c/083N0XhA/138-separate-3d-viewer-from-other-code">multiple cameras concurrently</a></td>
+					<td class="orange"><a href="https://trello.com/c/6J2u7PIp/497-support-for-plug-ins">support for plug-ins (traffic, people, defect detector)</a></td>
 				</tr>
 				<tr>
-					<td class="version">v ?</td>
+					<td class="version">v N+4</td>
 					<td>&nbsp;</td>
 					<td>&nbsp;</td>
 					<td>&nbsp;</td>
@@ -144,13 +144,13 @@ title: Roadmap
 					<td class="blue"><a href="https://trello.com/c/kMLCthN1/148-3d-world-editor">route editor</a></td>
 					<td class="red"><a href="https://trello.com/c/T8MAzkUS/503-signalman-role">dispatcher/signalman role</a></td>
 					<td class="green"><a href="https://trello.com/c/6oOPGiUI/214-heat-shimmer-effect-diesel-steam-exhaust">heat shimmer for exhaust</a></td>
-					<td class="orange"><a href="https://trello.com/c/6J2u7PIp/497-support-for-plug-ins">support for plug-ins (traffic, people, defect detector)</a></td>
+					<td class="orange"><a href=""></a></td>
 				</tr>
 				<tr>
 					<td class="blue"><a href=""></a></td>
 					<td class="red"><a href="https://trello.com/c/pof5Vwoo/499-timetables-for-multi-player-use">timetable for multi-player</a></td>
 					<td class="green"><a href="https://trello.com/c/JWrGWXYd/112-content-defined-static-cameras">static cameras</a></td>
-					<td class="orange"><a href="https://trello.com/c/Mjmi2WsI/238-standalone-dispatcher-that-handles-server-host-admin">multi-player server</a></td>
+					<td class="orange"><a href=""></a></td>
 				</tr>
 			</tbody>
 		</table>

--- a/discover/version-1-6/index.html
+++ b/discover/version-1-6/index.html
@@ -1,0 +1,99 @@
+---
+layout: default
+section: Discover
+title: Version 1.6
+---
+
+<div class="row">
+<div class="col-md-1"></div>
+<div class="col-md-10">
+    <h2>New in Open Rails 1.6 (since 1.5)</h2>
+    <p>
+    A summary of the new and improved features can be found below. 
+    </p><p>
+    <a href="https://launchpad.net/or/+milestone/1.6" target="_blank">Important bugs</a> have been fixed in this release.
+    Please keep <a href="/contribute/reporting-bugs/" target="_blank">reporting bugs and suggesting new features</a> 
+    so Open Rails can continue to improve.
+    </p>
+</div>
+</div>
+<div class="row">
+<div class="col-md-1"></div>
+<div class="col-md-6">
+    <!-- <h3>Headlines</h3>
+    <ul>
+        <li>Container Loading and Unloading</li>
+    </ul> -->
+    <h3>What's been added</h3>
+    <ul>
+        <li>auto-save option</li>
+        <li>timetable has auto-pilot and switch player train options</li>    
+        <li>detailed map which tracks player train</li>    
+        <li>self-installing content</li>    
+        <li>new rolling stock lighting controls, including horn-activated flashing lights</li>    
+        <li>partial turntables</li>    
+        <li>cab controls operated remotely from a tablet or control desk</li>    
+        <li>animations for cab windows</li>    
+        <li>options to configure RailDriver</li>    
+        <li>more accurate wheelslip using Polach adhesion</li>    
+        <li>duplex and booster steam engines (e.g. T1 class)</li>    
+        <li>cloud-free skies</li>    
+        <li>sounds conditional on season, weather and time of day</li>    
+        <li>more air and dynamic brake options for locos</li>    
+        <li>mouse control for scripted brake controllers</li>    
+    </ul>
+
+    <h3>What's been improved</h3>
+    <ul>
+        <li>sky, sunrise and sunset appearance</li>
+        <li>auto-pilot extended to timetables</li>    
+        <li>wheelslip, exhaust and steam</li>    
+        <li>layout of map window</li>    
+        <li>F9 menu for controlling cars and brakes</li>    
+        <li>controls for electric locos</li>    
+        <li>air brake features for both European and American brake systems</li>    
+        <li>accurate friction simulation for 4 types of brake shoes</li>    
+        <li>superelevation system rewritten to be smoother and more configurable</li>
+    </ul>
+    
+    <h3>Other changes</h3>
+    <ul>
+        <li>distracting “z-fighting” has been minimised</li>
+        <li>inactive windows are indicated when several windows are open</li>    
+        <li>jerky motion in heavily-signalled areas minimised</li>    
+    </ul>
+</div>
+<div class="col-md-1"></div>
+<div class="col-md-4">
+    <h3>Contributors to this release</h3>
+    <ul>
+        <li>albertosaurio65</li>
+        <li>cesarBLG</li>
+        <li>cjakeman</li>
+        <li>Csantucci</li>
+        <li>Fred-si</li>
+        <li>Hirek193</li>
+        <li>Looky1173</li>
+        <li>mbm-OR</li>
+        <li>peternewell</li>
+        <li>Prabs09</li>
+        <li>pzgulyas</li>
+        <li>Roeterdink</li>
+        <li>rwf-rr</li>
+        <li>Sharpe49</li>
+        <li>SteelFill</li>
+        <li>strawberryfield</li>
+        <li>sweiland-openrails</li>
+        <li>twpol</li>
+        <li>Weter-ORTS</li>
+    </ul>
+
+    <h3>Detailed changelog</h3>
+    <p>
+    A <a href="https://launchpad.net/or/+milestone/1.6" target="_blank">full list of changes</a> is available.
+    </p>
+    <h3><a href="../version-1-5/">Changes in previous version</a></h3>
+    <p>&nbsp;</p>
+</div>
+</div>
+</div>

--- a/index.html
+++ b/index.html
@@ -32,16 +32,18 @@ preambles:
   <div class="col-md-4 divider">
     
     <div class="heading">
-      <h4>Key Changes in v1.5</h4>
+      <h4>Key Changes in v1.6</h4>
     </div>
     <p>
-      Container loading and unloading
+      Self-installing content
     </p><p>
-      End Of Train (EOT) devices
+      Auto-save option
     </p><p>
-      64-bit compatibility lifting the 3GB RAM limit
+      Better superelevation
     </p><p>
-      Many <a href="/discover/version-1-5/">more additions and improvements</a> are listed here.
+      More detailed F9 menu for controlling cars and brakes
+    </p><p>
+      Many more <a href="/discover/version-1-6/">additions and improvements</a> are listed here.
     </p>
   </div>
   <div class="col-md-4 divider">
@@ -63,28 +65,31 @@ preambles:
       <h4>Videos</h4>
     </div>
     <div class="headed_content">
-      <h5>Review on YouTube</h5>
+      <h5>Reviews</h5>
       <p>
         <a href="https://www.youtube.com/watch?v=lj_XKQI4NFI" target="_blank">At The Railyard: SP Shasta Route Review</a></h5>
       </p>
+      <div>
+        <h5><a href="http://www.attherailyard.com" target="_blank">At The Railyard</a></h5>
+        <p>
+          In his Series 5, Nicholas Ozorak publishes
+          <a href="https://attherailyard.com/index.php/2013/09/25/open-rails-full-bucket-line/" target="_blank">
+            a review of the fictional Full Bucket Line running in Open Rails</a>.
+        </p>
+      </div>
     </div>
-    <div class="headed_content">
+    <p>&nbsp;</p>
+    <div>
+      <h5><a href="https://www.youtube.com/watch?v=VmV3kr1Mxkw">REX 1959 Prešov-Košice</a></h5>
+      <h5><a href="https://www.youtube.com/watch?v=c5KHpxTLdhs">Regionale Ventimiglia - Savona</a></h5>
+      <h5><a href="https://youtu.be/vXFHUSux45w?t=296" target="_blank">Great Eastern 2 Norwich to Ipswich Class 86</a></h5>
+      <h5><a href="https://www.youtube.com/watch?v=EBGro3ASSeE" target="_blank">It's not chicken feed!</a></h5>
+      <p>&nbsp;</p>
       <h5><a href="https://youtu.be/ZY2_UYvacXg" target="_blank">New features in Release 1.5.1</a></h5>
     </div>
     <p>&nbsp;</p>
     <div>
-      <h5><a href="https://youtu.be/8RGw7hKdNPM" target="_blank">New features in Release 1.4</a></h5>
-    </div>
-    <p>&nbsp;</p>
-    <div>
-      <h5>Review <a href="http://www.attherailyard.com" target="_blank">At The Railyard</a></h5>
-      <p>
-        In his Series 5, Nicholas Ozorak publishes
-        <a href="https://attherailyard.com/index.php/2013/09/25/open-rails-full-bucket-line/" target="_blank">
-          a review of the fictional Full Bucket Line running in Open Rails</a>.
-      </p><p>
-        Find more videos with this <a href="https://www.youtube.com/results?search_query=open+rails" target="_blank">YouTube search</a>.
-      </p>
+      Find more videos with this <a href="https://www.youtube.com/results?search_query=open+rails" target="_blank">YouTube search</a>.
     </div>
   </div>
 </div>


### PR DESCRIPTION
Better make this a DRAFT as:
Notifications.json uses "www.openrails.org/discover/latest_stable_version" to take the user to the summary page for whichever is the latest version.
I've put in a redirection page at /discover/latest_stable_version but it's taking me to the 404 page.
