### PR TITLE
fix: Adds missing re-direct

### DIFF
--- a/discover/latest-stable-version/index.markdown
+++ b/discover/latest-stable-version/index.markdown
@@ -1,0 +1,6 @@
+---
+layout: default
+section: Discover
+title: Latest Stable Version
+redirect_to: https://www.openrails.org/discover/version-1-5/
+---


### PR DESCRIPTION
This re-direct links to v1.5, so the Notifications will now work correctly when this button is pressed.

![image](https://github.com/user-attachments/assets/882eef13-8f89-4327-962b-9f2d3eca7ece)


There was a question about whether re-directs work locally and it seems you were right. They link fine to an existing webpage on the Internet, but not at all to a local page.